### PR TITLE
Update sunwell.js to use a middle baseline

### DIFF
--- a/sunwell.js
+++ b/sunwell.js
@@ -656,7 +656,7 @@
         } else {
             bufferRowCtx.fillStyle = '#000';
         }
-        bufferRowCtx.textBaseline = 'hanging';
+        bufferRowCtx.textBaseline = 'middle';
 
         bufferRowCtx.font = fontSize + 'px/1em "' + sunwell.settings.bodyFont + '", sans-serif';
 


### PR DESCRIPTION
Using a middle baseline should fix the text being cut off on iOS and macOS. Referenced in issue #7.